### PR TITLE
Changes SSL Version from SSLv3 (insecure) to TLS 1.2 (secure).

### DIFF
--- a/classes/DuraCloudConnection.inc.php
+++ b/classes/DuraCloudConnection.inc.php
@@ -247,7 +247,7 @@ class DuraCloudConnection {
 			curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 			curl_setopt($ch, CURLOPT_HEADER, 1);
 			curl_setopt($ch, CURLOPT_USERAGENT, 'DuraCloud-PHP ' . DURACLOUD_PHP_VERSION); 
-			curl_setopt($ch, CURLOPT_SSLVERSION, 3);
+			curl_setopt($ch, CURLOPT_SSLVERSION, 6);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
 		}


### PR DESCRIPTION
Hey Alec, 

We upgraded our servers recently:  we no longer support SSL 3 due to its security vulnerabilities.  Our servers do support TLS 1.2, TLS 1.1, and TLS 1.0.  This change sets it to tls 1.2 (ie 6).  